### PR TITLE
Nested Workspaces

### DIFF
--- a/CrossMod/CrossMod.csproj
+++ b/CrossMod/CrossMod.csproj
@@ -105,6 +105,7 @@
     <Compile Include="IO\IO_PLY.cs" />
     <Compile Include="IO\IO_SEANIM.cs" />
     <Compile Include="IO\IO_SMD.cs" />
+    <Compile Include="Nodes\DirectoryNode.cs" />
     <Compile Include="Nodes\IExportableAnimationNode.cs" />
     <Compile Include="Nodes\IExportableTextureNode.cs" />
     <Compile Include="Nodes\NUANIM_Node.cs" />

--- a/CrossMod/GUI/ModelViewport.cs
+++ b/CrossMod/GUI/ModelViewport.cs
@@ -118,6 +118,10 @@ namespace CrossMod.GUI
             glViewport.OnRenderFrame += RenderNode;
         }
 
+        /// <summary>
+        /// Populates the meshes tab, and binds the given model to subcomponents such as the animation bar.
+        /// </summary>
+        /// <param name="model"></param>
         private void DisplayMeshes(RModel model)
         {
             animationBar.Model = model;
@@ -138,6 +142,10 @@ namespace CrossMod.GUI
             }
         }
 
+        /// <summary>
+        /// Populates the bones tab, and binds the given skeleton to subcomponents such as the animation bar
+        /// </summary>
+        /// <param name="skeleton"></param>
         private void DisplaySkeleton(RSkeleton skeleton)
         {
             if (skeleton == null)

--- a/CrossMod/MainForm.Designer.cs
+++ b/CrossMod/MainForm.Designer.cs
@@ -39,9 +39,9 @@ namespace CrossMod
             this.experimentalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.batchRenderModelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.printMaterialValuesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.printAttributesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fileTree = new System.Windows.Forms.TreeView();
             this.contentBox = new System.Windows.Forms.GroupBox();
-            this.printAttributesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -136,6 +136,13 @@ namespace CrossMod
             this.printMaterialValuesToolStripMenuItem.Text = "Print Material Values";
             this.printMaterialValuesToolStripMenuItem.Click += new System.EventHandler(this.printMaterialValuesToolStripMenuItem_Click);
             // 
+            // printAttributesToolStripMenuItem
+            // 
+            this.printAttributesToolStripMenuItem.Name = "printAttributesToolStripMenuItem";
+            this.printAttributesToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
+            this.printAttributesToolStripMenuItem.Text = "Print Attributes";
+            this.printAttributesToolStripMenuItem.Click += new System.EventHandler(this.printAttributesToolStripMenuItem_Click);
+            // 
             // fileTree
             // 
             this.fileTree.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -146,6 +153,7 @@ namespace CrossMod
             this.fileTree.Name = "fileTree";
             this.fileTree.Size = new System.Drawing.Size(241, 538);
             this.fileTree.TabIndex = 2;
+            this.fileTree.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.fileTree_BeforeExpand);
             this.fileTree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.fileTree_AfterSelect);
             this.fileTree.MouseUp += new System.Windows.Forms.MouseEventHandler(this.fileTree_MouseUp);
             // 
@@ -160,13 +168,6 @@ namespace CrossMod
             this.contentBox.TabIndex = 3;
             this.contentBox.TabStop = false;
             this.contentBox.Text = "Viewer";
-            // 
-            // printAttributesToolStripMenuItem
-            // 
-            this.printAttributesToolStripMenuItem.Name = "printAttributesToolStripMenuItem";
-            this.printAttributesToolStripMenuItem.Size = new System.Drawing.Size(186, 22);
-            this.printAttributesToolStripMenuItem.Text = "Print Attributes";
-            this.printAttributesToolStripMenuItem.Click += new System.EventHandler(this.printAttributesToolStripMenuItem_Click);
             // 
             // MainForm
             // 

--- a/CrossMod/MainForm.Designer.cs
+++ b/CrossMod/MainForm.Designer.cs
@@ -42,7 +42,12 @@ namespace CrossMod
             this.printAttributesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fileTree = new System.Windows.Forms.TreeView();
             this.contentBox = new System.Windows.Forms.GroupBox();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.menuStrip1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
             this.SuspendLayout();
             // 
             // menuStrip1
@@ -145,13 +150,12 @@ namespace CrossMod
             // 
             // fileTree
             // 
-            this.fileTree.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left)));
+            this.fileTree.Dock = System.Windows.Forms.DockStyle.Fill;
             this.fileTree.HideSelection = false;
             this.fileTree.ItemHeight = 24;
-            this.fileTree.Location = new System.Drawing.Point(12, 27);
+            this.fileTree.Location = new System.Drawing.Point(0, 0);
             this.fileTree.Name = "fileTree";
-            this.fileTree.Size = new System.Drawing.Size(241, 538);
+            this.fileTree.Size = new System.Drawing.Size(240, 538);
             this.fileTree.TabIndex = 2;
             this.fileTree.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.fileTree_BeforeExpand);
             this.fileTree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.fileTree_AfterSelect);
@@ -159,29 +163,50 @@ namespace CrossMod
             // 
             // contentBox
             // 
-            this.contentBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.contentBox.Location = new System.Drawing.Point(259, 27);
+            this.contentBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.contentBox.Location = new System.Drawing.Point(0, 0);
             this.contentBox.Name = "contentBox";
-            this.contentBox.Size = new System.Drawing.Size(601, 538);
+            this.contentBox.Size = new System.Drawing.Size(604, 538);
             this.contentBox.TabIndex = 3;
             this.contentBox.TabStop = false;
             this.contentBox.Text = "Viewer";
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.splitContainer1.Location = new System.Drawing.Point(12, 27);
+            this.splitContainer1.Name = "splitContainer1";
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.fileTree);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.contentBox);
+            this.splitContainer1.Size = new System.Drawing.Size(848, 538);
+            this.splitContainer1.SplitterDistance = 240;
+            this.splitContainer1.TabIndex = 4;
             // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(872, 577);
-            this.Controls.Add(this.contentBox);
-            this.Controls.Add(this.fileTree);
+            this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.menuStrip1);
             this.MainMenuStrip = this.menuStrip1;
             this.Name = "MainForm";
             this.Text = "CrossMod";
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -203,6 +228,7 @@ namespace CrossMod
         private System.Windows.Forms.ToolStripMenuItem frameSelectionToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem printMaterialValuesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem printAttributesToolStripMenuItem;
+        private System.Windows.Forms.SplitContainer splitContainer1;
     }
 }
 

--- a/CrossMod/Nodes/DirectoryNode.cs
+++ b/CrossMod/Nodes/DirectoryNode.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CrossMod.Nodes
+{
+    /// <summary>
+    /// Class for all Directory entries in the file system. Executing Open()
+    /// populates sub-nodes, and executing OpenNodes() calls Open() on all sub-nodes.
+    /// </summary>
+    class DirectoryNode : FileNode
+    {
+        private bool isOpened = false;
+        private bool isNestedOpened = false;
+
+        private static readonly List<Type> fileNodeTypes = (from domainAssembly in AppDomain.CurrentDomain.GetAssemblies()
+                                                            from assemblyType in domainAssembly.GetTypes()
+                                                            where typeof(FileNode).IsAssignableFrom(assemblyType)
+                                                            select assemblyType).ToList();
+
+        /// <summary>
+        /// Creates a new DirectoryNode. The FilePath is set to the given value
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="isRoot">Whether this is the topmost parent. Decides whether to display full or partial name.</param>
+        public DirectoryNode(string path, bool isRoot=true) : base(path)
+        {
+            Text = (isRoot) ? Path.GetDirectoryName(path) : Path.GetFileName(path);
+            SelectedImageKey = "folder";
+            ImageKey = "folder";
+        }
+
+        /// <summary>
+        /// Reads the directory, populating all subnodes.
+        /// Subnodes are not opened, use OpenNodes() afterwards to do that.
+        /// Repeated executions are no-ops.
+        /// </summary>
+        public override void Open()
+        {
+            if (isOpened)
+            {
+                return;
+            }
+
+            foreach (var name in Directory.EnumerateFileSystemEntries(AbsolutePath))
+            {
+                if (Directory.Exists(name))
+                {
+                    var dirNode = new DirectoryNode(name, isRoot:false);
+                    this.Nodes.Add(dirNode);
+                }
+                else
+                {
+                    this.Nodes.Add(CreateFileNode(fileNodeTypes, name));
+                }
+            }
+
+            isOpened = true;
+        }
+
+        /// <summary>
+        /// Opens all nodes. Make sure to call after Open().
+        /// Repeated executions result in a no-op.
+        /// </summary>
+        public void OpenNodes()
+        {
+            if (isNestedOpened)
+            {
+                return;
+            }
+
+            foreach (var node in this.Nodes)
+            {
+                (node as FileNode)?.Open();
+            }
+
+            isNestedOpened = true;
+        }
+
+        /// <summary>
+        /// Internal helper to open a file entry.
+        /// </summary>
+        /// <param name="Types"></param>
+        /// <param name="file"></param>
+        /// <returns></returns>
+        private FileNode CreateFileNode(IEnumerable<Type> Types, string file)
+        {
+            // TODO: Possible separation of concerns improvement: IFileLoader injected into DirectoryNode.
+
+            FileNode fileNode = null;
+
+            string Extension = Path.GetExtension(file);
+
+            foreach (var type in Types)
+            {
+                if (type.GetCustomAttributes(typeof(FileTypeAttribute), true).FirstOrDefault() is FileTypeAttribute attr)
+                {
+                    if (attr.Extension.Equals(Extension))
+                    {
+                        fileNode = (FileNode)Activator.CreateInstance(type, file);
+                    }
+                }
+            }
+
+            if (fileNode == null)
+                fileNode = new FileNode(file);
+
+            // Change style of unrenderable nodes
+            if (!(fileNode is IRenderableNode))
+            {
+                fileNode.ForeColor = Color.Gray;
+            }
+            
+            fileNode.Text = Path.GetFileName(file);
+            return fileNode;
+        }
+    }
+}

--- a/CrossMod/Nodes/DirectoryNode.cs
+++ b/CrossMod/Nodes/DirectoryNode.cs
@@ -29,7 +29,7 @@ namespace CrossMod.Nodes
         /// <param name="isRoot">Whether this is the topmost parent. Decides whether to display full or partial name.</param>
         public DirectoryNode(string path, bool isRoot=true) : base(path)
         {
-            Text = (isRoot) ? Path.GetDirectoryName(path) : Path.GetFileName(path);
+            Text = (isRoot) ? Path.GetFullPath(path) : Path.GetFileName(path);
             SelectedImageKey = "folder";
             ImageKey = "folder";
         }

--- a/CrossMod/Nodes/FileNode.cs
+++ b/CrossMod/Nodes/FileNode.cs
@@ -2,9 +2,23 @@
 
 namespace CrossMod.Nodes
 {
+    /// <summary>
+    /// Base class for all TreeView nodes that represent a file system entry.
+    /// Contains the string absolute path and an overridable Open() method.
+    /// </summary>
     public class FileNode : TreeNode
     {
-        public virtual void Open(string Path)
+        /// <summary>
+        /// Path to the file system entry that this FileNode represents
+        /// </summary>
+        public string AbsolutePath { get; protected set; }
+
+        public FileNode(string path)
+        {
+            AbsolutePath = path;
+        }
+
+        public virtual void Open()
         {
 
         }

--- a/CrossMod/Nodes/MATL_Node.cs
+++ b/CrossMod/Nodes/MATL_Node.cs
@@ -8,15 +8,15 @@ namespace CrossMod.Nodes
     {
         public MATL Material { get; set; }
         
-        public MATL_Node()
+        public MATL_Node(string path) : base(path)
         {
             ImageKey = "material";
             SelectedImageKey = "material";
         }
 
-        public override void Open(string Path)
+        public override void Open()
         {
-            if (SSBH.TryParseSSBHFile(Path, out ISSBH_File ssbhFile))
+            if (SSBH.TryParseSSBHFile(AbsolutePath, out ISSBH_File ssbhFile))
             {
                 if (ssbhFile is MATL)
                 {

--- a/CrossMod/Nodes/NUANIM_Node.cs
+++ b/CrossMod/Nodes/NUANIM_Node.cs
@@ -12,15 +12,15 @@ namespace CrossMod.Nodes
     {
         private ANIM animation;
 
-        public NUANIM_Node()
+        public NUANIM_Node(string path): base(path)
         {
             ImageKey = "animation";
             SelectedImageKey = "animation";
         }
         
-        public override void Open(string Path)
+        public override void Open()
         {
-            if (SSBH.TryParseSSBHFile(Path, out ISSBH_File SSBHFile))
+            if (SSBH.TryParseSSBHFile(AbsolutePath, out ISSBH_File SSBHFile))
             {
                 if (SSBHFile is ANIM anim)
                 {

--- a/CrossMod/Nodes/NUHLPB_Node.cs
+++ b/CrossMod/Nodes/NUHLPB_Node.cs
@@ -9,15 +9,15 @@ namespace CrossMod.Nodes
     {
         public HLPB helperBones;
 
-        public NUHLPB_Node()
+        public NUHLPB_Node(string path): base(path)
         {
             ImageKey = "skeleton";
             SelectedImageKey = "skeleton";
         }
         
-        public override void Open(string Path)
+        public override void Open()
         {
-            if (SSBH.TryParseSSBHFile(Path, out ISSBH_File ssbhFile))
+            if (SSBH.TryParseSSBHFile(AbsolutePath, out ISSBH_File ssbhFile))
             {
                 if (ssbhFile is HLPB)
                 {

--- a/CrossMod/Nodes/NUMDL_Node.cs
+++ b/CrossMod/Nodes/NUMDL_Node.cs
@@ -16,7 +16,7 @@ namespace CrossMod.Nodes
         private MODL _model;
         private IRenderable renderableNode = null;
 
-        public NUMDL_Node()
+        public NUMDL_Node(string path): base(path)
         {
             ImageKey = "model";
             SelectedImageKey = "model";
@@ -90,9 +90,9 @@ namespace CrossMod.Nodes
             return renderableNode;
         }
 
-        public override void Open(string Path)
+        public override void Open()
         {
-            if (SSBH.TryParseSSBHFile(Path, out ISSBH_File ssbhFile))
+            if (SSBH.TryParseSSBHFile(AbsolutePath, out ISSBH_File ssbhFile))
             {
                 if (ssbhFile is MODL)
                 {

--- a/CrossMod/Nodes/NUMSHB_Node.cs
+++ b/CrossMod/Nodes/NUMSHB_Node.cs
@@ -64,15 +64,15 @@ namespace CrossMod.Nodes
         public MESH mesh;
         public ADJB ExtendedMesh;
 
-        public NUMSHB_Node()
+        public NUMSHB_Node(string path): base(path)
         {
             ImageKey = "mesh";
             SelectedImageKey = "mesh";
         }
 
-        public override void Open(string Path)
+        public override void Open()
         {
-            string ADJB = System.IO.Path.GetDirectoryName(Path) + "/model.adjb";
+            string ADJB = System.IO.Path.GetDirectoryName(AbsolutePath) + "/model.adjb";
             System.Console.WriteLine(ADJB);
             if (File.Exists(ADJB))
             {
@@ -80,7 +80,7 @@ namespace CrossMod.Nodes
                 ExtendedMesh.Read(ADJB);
             }
 
-            if (SSBH.TryParseSSBHFile(Path, out ISSBH_File ssbhFile))
+            if (SSBH.TryParseSSBHFile(AbsolutePath, out ISSBH_File ssbhFile))
             {
                 if (ssbhFile is MESH)
                 {

--- a/CrossMod/Nodes/NUTEX_Node.cs
+++ b/CrossMod/Nodes/NUTEX_Node.cs
@@ -79,7 +79,7 @@ namespace CrossMod.Nodes
             { NUTEX_FORMAT.B8G8R8A8_SRGB, PixelFormat.Bgra },
         };
 
-        public NUTEX_Node()
+        public NUTEX_Node(string path): base(path)
         {
             ImageKey = "texture";
             SelectedImageKey = "texture";
@@ -90,9 +90,9 @@ namespace CrossMod.Nodes
             return Text.Contains(".") ? Text.Substring(0, Text.IndexOf(".")) : Text;
         }
 
-        public override void Open(string path)
+        public override void Open()
         {
-            using (BinaryReader reader  = new BinaryReader(new FileStream(path, FileMode.Open)))
+            using (BinaryReader reader  = new BinaryReader(new FileStream(AbsolutePath, FileMode.Open)))
             {
                 Mipmaps = new List<byte[]>();
                 // TODO: Why are there empty streams?

--- a/CrossMod/Nodes/SHAN_Node.cs
+++ b/CrossMod/Nodes/SHAN_Node.cs
@@ -11,15 +11,15 @@ namespace CrossMod.Nodes
     public class SHAN_Node : FileNode
     {
 
-        public SHAN_Node()
+        public SHAN_Node(string path) : base(path)
         {
             ImageKey = "animation";
             SelectedImageKey = "animation";
         }
 
-        public override void Open(string Path)
+        public override void Open()
         {
-            using (BinaryReader R = new BinaryReader(new FileStream(Path, FileMode.Open)))
+            using (BinaryReader R = new BinaryReader(new FileStream(AbsolutePath, FileMode.Open)))
             {
                 char[] Magic = R.ReadChars(4);
                 uint DefaultID = R.ReadUInt32();

--- a/CrossMod/Nodes/SKEL_Node.cs
+++ b/CrossMod/Nodes/SKEL_Node.cs
@@ -13,16 +13,16 @@ namespace CrossMod.Nodes
 
         private RSkeleton Skeleton;
 
-        public SKEL_Node()
+        public SKEL_Node(string path) : base(path)
         {
             ImageKey = "skeleton";
             SelectedImageKey = "skeleton";
         }
 
-        public override void Open(string Path)
+        public override void Open()
         {
             ISSBH_File SSBHFile;
-            if (SSBH.TryParseSSBHFile(Path, out SSBHFile))
+            if (SSBH.TryParseSSBHFile(AbsolutePath, out SSBHFile))
             {
                 if(SSBHFile is SKEL)
                 {

--- a/CrossMod/Rendering/ShaderContainer.cs
+++ b/CrossMod/Rendering/ShaderContainer.cs
@@ -5,6 +5,9 @@ using System.IO;
 
 namespace CrossMod.Rendering
 {
+    /// <summary>
+    /// A global static class used to create and retrieve shaders.
+    /// </summary>
     public static class ShaderContainer
     {
         private static Dictionary<string, Shader> shaderByName = new Dictionary<string, Shader>();


### PR DESCRIPTION
Implemented recursive tree loading with lazy loading (deferred to directory expansion). The fileview can now be resized manually as well.

FileNodes were tweaked to take the path on construction instead of during Open(). DirectoryNode's Open() method creates the sub nodes, and DirectoryNode#OpenFiles() executes Open() on all file nodes. DirectoryNode#OpenFiles() is called during the file tree's expanded event.

I tested a few scenarios except for animation exporting. Haven't figured out how animation exporting works, as it seems to want to load a skeleton file, and skeleton's have no right click export. However, I have no reason to believe that animation exporting would start to fail, especially since FileNodes are forced to always have a path assigned to it (and Open() is still executed).

There are a few potential things that could be added. Perhaps directories containing a model could display the model when selected? Perhaps directories with a model could have a different icon? Is "Open Model Folder" not clearing the workspace still intended behavior? Let me know what sounds good!

![image](https://user-images.githubusercontent.com/1286721/51293928-c597ba00-19de-11e9-8aa7-8b7efffd9fa0.png)
